### PR TITLE
Move settings to environment variables

### DIFF
--- a/.env-local
+++ b/.env-local
@@ -1,2 +1,3 @@
 SECRET_KEY="hello"
 DEBUG="yes"
+INSECURE="yes"

--- a/.env-local
+++ b/.env-local
@@ -1,0 +1,2 @@
+SECRET_KEY="hello"
+DEBUG="yes"

--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,6 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+
+# dotenv
+.env

--- a/README.md
+++ b/README.md
@@ -16,11 +16,12 @@ Produce an API that would allow us to look up sentencing guidelines programmatic
 
 ## Running the app
 
-- Create a virtualenv `virtualenv env`
-- Activate it `source env/bin/activate`
-- Install requirements `pip install -r requirements.txt`
+- Create a virtualenv: `virtualenv env`
+- Activate it: `source env/bin/activate`
+- Install dependencies: `pip install -r requirements.txt`
 - Run the migrations `python manage.py migrate`
 - Create a superuser account `python manage.py createsuperuser --email admin@example.com --username admin`
+- Configure the local environment: `cp .env-local .env`
 - Run the app `python manage.py runserver`
 
 The app should then be available at http://127.0.0.1:8000/

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 django>=2.1.6
 djangorestframework==3.9.1
 pytz==2018.9
+python-dotenv[cli]

--- a/sentencing_guidelines_api/settings.py
+++ b/sentencing_guidelines_api/settings.py
@@ -11,6 +11,8 @@ https://docs.djangoproject.com/en/2.1/ref/settings/
 """
 
 import os
+from dotenv import load_dotenv
+load_dotenv()
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -19,14 +21,14 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/2.1/howto/deployment/checklist/
 
-# SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = '!j0sh4^8j(7h+3trzch+(nm=)q&alfn2*k@!(*o$r9cv^7zhbi'
+SECRET_KEY = os.environ['SECRET_KEY']
+DEBUG = bool(os.environ.get('DEBUG', ''))
 
-# SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = True
+CSRF_COOKIE_SECURE = not os.environ.get("INSECURE", '')
+SESSION_COOKIE_SECURE = not os.environ.get("INSECURE", '')
 
-ALLOWED_HOSTS = []
-
+allowed_hosts_string = os.environ.get('ALLOWED_HOSTS', '')
+ALLOWED_HOSTS = allowed_hosts_string.split(',') if allowed_hosts_string else []
 
 # Application definition
 
@@ -75,10 +77,13 @@ WSGI_APPLICATION = 'sentencing_guidelines_api.wsgi.application'
 # Database
 # https://docs.djangoproject.com/en/2.1/ref/settings/#databases
 
+LOCAL_ENGINE = 'django.db.backends.sqlite3'
+LOCAL_NAME = os.path.join(BASE_DIR, 'db.sqlite3')
+
 DATABASES = {
     'default': {
-        'ENGINE': 'django.db.backends.sqlite3',
-        'NAME': os.path.join(BASE_DIR, 'db.sqlite3'),
+        'ENGINE': os.environ.get('DATABASE_ENGINE', LOCAL_ENGINE),
+        'NAME': os.environ.get('DATABASE_NAME', LOCAL_NAME),
     }
 }
 
@@ -105,7 +110,7 @@ AUTH_PASSWORD_VALIDATORS = [
 # Internationalization
 # https://docs.djangoproject.com/en/2.1/topics/i18n/
 
-LANGUAGE_CODE = 'en-us'
+LANGUAGE_CODE = 'en-gb'
 
 TIME_ZONE = 'UTC'
 


### PR DESCRIPTION
# Motivation

So far we've just got the django default settings.py.

We need to change some things before we deploy this to heroku:
https://docs.djangoproject.com/en/2.1/howto/deployment/checklist/

In particular, the secret key needs to be secret!

We'll follow the 12 factor approach and move all of these settings
to environment variables:

> The twelve-factor app stores config in environment variables (often shortened to env vars or env). Env vars are easy to change between deploys without changing any code; unlike config files, there is little chance of them being checked into the code repo accidentally; and unlike custom config files, or other config mechanisms such as Java System Properties, they are a language- and OS-agnostic standard.

https://12factor.net/config

# Configuring the local environment
I'm using a tool called [dotenv](https://github.com/theskumar/python-dotenv) to manage the environment variables locally so the app still works.

Dotenv reads key/value pairs from a `.env` file and allows the application to read them as environment variables.

This means we can still have a file with all the settings for local development.

I've added the `.env` file to the `.gitignore`, because we don't want it to be picked up in production.

After this change, you'll need to run the following to pick up the local settings:

```
pip install -r requirements.txt
cp .env-local .env
```